### PR TITLE
Tweak Video and Photo Conversion

### DIFF
--- a/packages/cast/src/index.js
+++ b/packages/cast/src/index.js
@@ -45,7 +45,7 @@ const byDate = reverse => {
 
 const extractMedia = (entries, baseUrl) => {
   return entries.reduce((result, entry) => {
-    const image = entry.previews.find(preview => preview.match('image-preview-1280'))
+    const image = entry.previews.find(preview => preview.match('image-preview-2048'))
     const title = path.parse(entry.files[0].filename).name
     if (entry.type == 'video') {
       const video = entry.previews.find(preview => preview.match('video-preview-720'))

--- a/packages/extractor/src/extract/image/image-resizer.js
+++ b/packages/extractor/src/extract/image/image-resizer.js
@@ -6,14 +6,14 @@ const log = require('@home-gallery/logger')('extractor.image.resize')
 const { getNativeCommand } = require('../utils/native-command')
 
 const jpgOptions = {
-  quality: 80,
+  quality: 100,
   progressive: true,
   optimiseCoding: true,
   mozjpeg: true // same as {trellisQuantisation: true, overshootDeringing: true, optimiseScans: true, quantisationTable: 3}
 }
 
 const vipsthumbnailJpgOptions = [
-  'Q=80', // jpg quality
+  'Q=100', // jpg quality
   'interlace',
   'optimize-coding',
   'trellis-quant', 'overshoot-deringing', 'optimize-scans', 'quant-table=3', // mozjpeg defaults

--- a/packages/extractor/src/extract/video/video.js
+++ b/packages/extractor/src/extract/video/video.js
@@ -35,16 +35,15 @@ function convertVideo(storage, entry, ffprobePath, ffmpegPath, cb) {
     .output(tmpFile)
     .videoCodec('libx264')
     .audioCodec('aac')
+    .size('50%')
     .outputOptions([
       '-y',
-      '-r 30', // frame rate
-      '-vf scale=-2:\'min(720,ih)\',format=yuv420p', // Scale to 720p without upscaling
       '-preset slow',
       '-tune film',
-      '-profile:v baseline',
-      '-level 3.0',
-      '-maxrate 4000k',
-      '-bufsize 8000k',
+      '-profile:v high',
+      '-level 4.0',
+      '-maxrate 6000k',
+      '-bufsize 12000k',
       '-movflags +faststart',
       '-b:a 128k',
       '-f mp4'

--- a/packages/extractor/src/index.js
+++ b/packages/extractor/src/index.js
@@ -49,7 +49,7 @@ const extractData = async (options) => {
   const videoFrameExtractor = createVideoFrameExtractor(ffmpegPath, ffprobePath)
   const storage = createStorage(storageDir);
 
-  const imagePreviewSizes = [1920, 1280, 800, 320, 128];
+  const imagePreviewSizes = [2048, 1920, 1280, 800, 320, 128];
   const videoFrameCount = 10;
   const apiServerImagePreviewSizes = [800, 320];
 

--- a/packages/webapp/src/map/EntryMarker.tsx
+++ b/packages/webapp/src/map/EntryMarker.tsx
@@ -22,14 +22,14 @@ export const EntryMarker = ({entry, dispatch}) => {
     iconSize: resize(entry, ICON_SIZE)
   }), [entry])
 
-  const [width, height] = useMemo(() => resize(entry, 320), [entry])
+  const [width, height] = useMemo(() => resize(entry, 800), [entry])
 
   const position = useMemo(() => L.latLng(entry.latitude, entry.longitude), [entry])
 
   return (
     <Marker key={entry.id} position={position} icon={icon}>
       <Popup closeButton={false} minWidth={width} maxWidth={width}>
-        <img src={getHigherPreviewUrl(entry.previews, 320)} width={width} height={height} onClick={() => dispatch({type: 'entryClick', entry})}/>
+        <img src={getHigherPreviewUrl(entry.previews, 800)} width={width} height={height} onClick={() => dispatch({type: 'entryClick', entry})}/>
         <p>File: {entry.files[0].index}:{entry.files[0].filename}</p>
         <p>Date: {formatDate('%d.%m.%Y %H:%M', entry.date)}</p>
       </Popup>

--- a/packages/webapp/src/single/MediaNav.tsx
+++ b/packages/webapp/src/single/MediaNav.tsx
@@ -24,14 +24,13 @@ export const MediaNav = ({current, prev, next, listLocation, showNavigation, dis
 
   useEffect(() => {
     let abort = false;
-    const large = width <= 1280 ? 1280 : 1920;
 
     const preloadPrevNext = async () => {
       if (!abort) {
-        await Promise.all([loadImage(getLowerPreviewUrl(next?.previews, 320)), loadImage(getLowerPreviewUrl(prev?.previews, 320))])
+        await Promise.all([loadImage(getLowerPreviewUrl(next?.previews, 800)), loadImage(getLowerPreviewUrl(prev?.previews, 800))])
       }
       if (!abort) {
-        await Promise.all([loadImage(getLowerPreviewUrl(next?.previews, large)), loadImage(getLowerPreviewUrl(prev?.previews, large))])
+        await Promise.all([loadImage(getLowerPreviewUrl(next?.previews, 2048)), loadImage(getLowerPreviewUrl(prev?.previews, 2048))])
       }
     }
 

--- a/packages/webapp/src/single/MediaViewImage.tsx
+++ b/packages/webapp/src/single/MediaViewImage.tsx
@@ -14,10 +14,8 @@ export const MediaViewImage = (props) => {
   const { width } = useBodyDimensions();
   const navigate = useNavigate();
 
-  const largeSize = width <= 1280 ? 1280 : 1920;
-
-  const smallUrl = getLowerPreviewUrl(previews, 320)
-  const largeUrl = getLowerPreviewUrl(previews, largeSize)
+  const smallUrl = getLowerPreviewUrl(previews, 800)
+  const largeUrl = getLowerPreviewUrl(previews, 2048)
   const [src, setSrc] = useState('');
 
   useEffect(() => {

--- a/packages/webapp/workbox-config.js
+++ b/packages/webapp/workbox-config.js
@@ -36,7 +36,7 @@ module.exports = {
       },
     },
     {
-      urlPattern: /-preview-320\.jpg$/,
+      urlPattern: /-preview-800\.jpg$/,
       handler: 'CacheFirst',
       options: {
         cacheName: 'images',


### PR DESCRIPTION
# Context
I had a bad quality video conversion when recording 4k (2160 x 3840) portrait videos. 
After running the import command, it converts to 406×720 which is not 720p or HD, and gets the wrong aspect ratio. 
It also set the frame rate to 30 fps which gives a flickering frame rate.

# Solution
I have updated some code to give me a better video quality after conversion with a respected lower file size.
So in this case, if we have 4k video it will reduce to 2k, and 1080p will reduce to 720p. 
It rescales both width and height to half of the size and also keeps the original fps for smooth motion.

# Additional
I have tweak also the image to support 2k conversion, keep the original quality, and increase the image default small and large size.

