### PR TITLE
Adding srandom sort method for more random results

### DIFF
--- a/packages/query/src/index.test.js
+++ b/packages/query/src/index.test.js
@@ -253,6 +253,7 @@ t.test('order by', async t => {
   t.same(await execQuery('year >= 2021 order by updated'), ['1223', '0987'], 'by updated')
   t.same(await execQuery('order by updated asc'), ['6718', '0987', '1223', '1234'], 'by updated asc')
   t.same(await execQuery('order by updated desc'), ['1234', '1223', '0987', '6718'], 'by updated desc')
+  t.resolves(execQuery('order by random'), 'by random')
 
   t.same(await execQuery('order by count(files)'), ['0987', '1223', '1234', '6718'], 'by count files')
   t.same(await execQuery('order by count(tags)'), ['1223', '1234', '0987', '6718'], 'by count tags')

--- a/packages/query/src/query/order-by.js
+++ b/packages/query/src/query/order-by.js
@@ -15,6 +15,15 @@ const sortBy = valueFn => (a, b) => {
   return result
 }
 
+function shuffle(array_init) {
+    array = array_init.slice(0)
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array
+}
+
 const orderRules = [
   {
     type: 'sortKey',
@@ -44,9 +53,15 @@ const orderRules = [
 const matchRule = (rule, ast) => (!rule.type || rule.type == ast.type) && (!rule.keys || rule.keys.includes(ast.value))
 
 const orderBy = (entries, ast) => {
+
+
   const orderByAst = ast.orderBy
   if (!orderByAst) {
     return entries
+  }
+ 
+  if (ast.orderBy.value == 'srandom') {
+      return shuffle(entries)
   }
 
   const match = orderRules.find(rule => matchRule(rule, orderByAst))


### PR DESCRIPTION
Addresses issue https://github.com/xemle/home-gallery/issues/99 by implementing a Durstenfeld shuffle on the entire array of query results. Allows distinct `srandom` sorting from `random` for the purposes of testing and validation.