### PR TITLE
walker: Follow symlinks when walking directories with images

### DIFF
--- a/packages/index/src/walker.js
+++ b/packages/index/src/walker.js
@@ -22,7 +22,7 @@ function readFileStats(dir, files, cb) {
     }
 
     const filename = path.join(dir, file);
-    fs.lstat(filename, (err, stat) => {
+    fs.stat(filename, (err, stat) => {
       if (hasError) {
         return;
       } else if (err) {


### PR DESCRIPTION
Follow symlinks to reach the final file containing the photo. Later when building the entries[1] it'll make sure it's a regular file before being examined.

[1]: https://github.com/xemle/home-gallery/blob/master/packages/database/src/build.js#L24


@xemle https://github.com/xemle/home-gallery/issues/105