### PR TITLE
MediaView next/prev change history

### DIFF
--- a/packages/webapp/src/single/MediaView.tsx
+++ b/packages/webapp/src/single/MediaView.tsx
@@ -108,6 +108,11 @@ export const MediaView = () => {
     navigate(`/view/${shortId}`, {state: {index, listLocation}});
   }
 
+  const viewNeighbour = (index: number) => {
+    const { shortId } = entries[index]
+    navigate(`/view/${shortId}`, {state: {index, listLocation}, replace: true});
+  }
+
   const dispatch = (action: any) => {
     const { type } = action
     let prevNextMatch = type.match(/(prev|next)(-(\d+))?/)
@@ -118,7 +123,7 @@ export const MediaView = () => {
       const offset = prevNextMatch[3] ? +prevNextMatch[3] : 1
       const negate = prevNextMatch[1] == 'prev' ? -1 : 1
       const i = Math.min(entries.length - 1, Math.max(0, index + (negate * offset)))
-      viewEntry(i)
+      viewNeighbour(i)
     } else if (type === 'similar' && current?.similarityHash) {
       navigate(`/similar/${current.shortId}`);
     } else if (type === 'toggleDetails') {


### PR DESCRIPTION
Changid so that wney you go to next/prev image/video it's not stored browser history.

Reson my intuition tells me that if I press the back button I should go back to the image wall and not to the previous image like any other photo app.

How it works now:
[Screencast from 24-02-24 00:20:36.webm](https://github.com/xemle/home-gallery/assets/36335235/cd62a67e-d219-4ecc-94ee-c551c7ba41be)
