### PR TITLE
Get original files

### DIFF
--- a/gallery.config-example.yml
+++ b/gallery.config-example.yml
@@ -58,6 +58,10 @@ sources:
     # Offline sources require an index file. Previews and meta data
     # should be extracted first before marking a source offline
     #offline: false
+    # Allows the original files to be downloaded via de webapp.  
+    # This adds a link to images of this source in the details view.  
+    # Sources set as `offline` won't be made available.  
+    #downloadable: true
     # Filename matcher for checksum recalculation
     # size-ctime-inode: this matcher should be used if possible, might
     #                   not work on windows

--- a/packages/cli/src/config/expand-defaults.js
+++ b/packages/cli/src/config/expand-defaults.js
@@ -30,6 +30,7 @@ export const expandConfigDefaults = (config, env) => {
       config.sources[i] = Object.assign({
         index: '{configDir}/{configPrefix}{basename(dir)}.idx',
         offline: false,
+        downloadable: false,
         excludeIfPresent: '.galleryignore'
       }, source)
     }

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -75,6 +75,11 @@ export function createApp(context) {
   router.use(getAuthMiddleware(config))
 
   router.use('/files', express.static(config.storage.dir, {index: false, maxAge: '2d', immutable: true}));
+  for (const source of config.sources) {
+    let idx = source.index;
+    idx = idx.substring(idx.lastIndexOf('/'), idx.lastIndexOf('.'));
+    router.use('/originals' + idx, express.static(source.dir, {index: false, maxAge: '2d', immutable: true, fallthrough: true}));
+  }
 
   const pluginApi = browserPlugin(context, '/plugins/')
   router.use('/plugins', pluginApi.static)

--- a/packages/webapp/src/single/Details.tsx
+++ b/packages/webapp/src/single/Details.tsx
@@ -78,7 +78,15 @@ export const Details = ({entry, dispatch}) => {
     ]
   }
 
-  const mainFilename = entry.files[0].filename.replace(/.*[/\\]/g, '')
+  const mainFileData = entry.files[0];
+  const mainFilename = mainFileData.filename.replace(/.*[/\\]/g, '')
+  const sourceConfig = appConfig.sources.find((value) => value && value.index === mainFileData.index);
+  const sourceLink = (text, withIcon = false) => {
+    if (!sourceConfig || sourceConfig.downloadable === false) return text;
+    return <a href={`sources/${mainFileData.index}/${mainFileData.filename}`} target="_blank">
+      {text} {withIcon ? <FontAwesomeIcon icon={icons.faArrowUpRightFromSquare} className="text-gray-300"/> : ''}
+    </a>
+  };
 
   const hasAddress = entry => entry.road || entry.city || entry.country
 
@@ -137,18 +145,14 @@ export const Details = ({entry, dispatch}) => {
             </div>
             <div>
               <p>
-                <a href={`originals/${entry.files[0].index}/${entry.files[0].filename}`} target="_blank">
-                  {mainFilename}
-                </a>
+                {sourceLink(mainFilename)}
               </p>
               <p>{simpleSearchLink(entry.type, 'type', entry.type)} {entry.id.substring(0, 7)}</p>
               <p>
                 {entry.duration > 0 && (
                   <>{humanizeDuration(entry.duration)}, </>
                 )}
-                <a href={`originals/${entry.files[0].index}/${entry.files[0].filename}`} target="_blank">
-                  {entry.width}x{entry.height}
-                </a>
+                {sourceLink(`${entry.width}x${entry.height}`, true)}
               </p>
             </div>
           </div>

--- a/packages/webapp/src/single/Details.tsx
+++ b/packages/webapp/src/single/Details.tsx
@@ -136,11 +136,20 @@ export const Details = ({entry, dispatch}) => {
               <FontAwesomeIcon icon={icons.faIdCard} className="text-gray-300"/>
             </div>
             <div>
-              <p>{mainFilename}</p>
+              <p>
+                <a href={`originals/${entry.files[0].index}/${entry.files[0].filename}`} target="_blank">
+                  {mainFilename}
+                </a>
+              </p>
               <p>{simpleSearchLink(entry.type, 'type', entry.type)} {entry.id.substring(0, 7)}</p>
-              <p>{entry.duration > 0 && (
-                <>{humanizeDuration(entry.duration)}, </>
-              )}{entry.width}x{entry.height}</p>
+              <p>
+                {entry.duration > 0 && (
+                  <>{humanizeDuration(entry.duration)}, </>
+                )}
+                <a href={`originals/${entry.files[0].index}/${entry.files[0].filename}`} target="_blank">
+                  {entry.width}x{entry.height}
+                </a>
+              </p>
             </div>
           </div>
           <div className="flex">


### PR DESCRIPTION
I'm not so sure if this is a good approach as there's no straight forward way to get the full path of the original image.  

The data has a `files` array, which has objects with both `index` and `filename`, so I used them to construct a unique path for each image.  
On the server side, there's no direct way to get the `index` value of the entry's file property, since the `sources` property of the config has an array with objects which `index` property has something like `/data/config/Pictures.idx`, so this PR assumes the name of the idx file is the same value as the one in the entry.  

This PR relates to #115, #159, and #165 (although probably there's more to do to exactly implement the feature of each issue)  