### PR TITLE
Social media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package-lock.json
 package-lock.json.cache
 gallery.config.yml
 latest-e2e
+brun.sh

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -22,7 +22,7 @@ const webappDir = path.join(__dirname, 'public')
 
 const log = Logger('server.app')
 
-function shouldCompress (req, res) {
+function shouldCompress(req, res) {
   if (req.headers['x-no-compression']) {
     return false
   }
@@ -60,7 +60,9 @@ const routerPrefix = basePath => {
  * @param {import('./types.js').TServerContext} context
  */
 export function createApp(context) {
-  const { config } = context
+  const {
+    config
+  } = context
   const app = express();
   app.disable('x-powered-by')
   app.enable('trust proxy')
@@ -69,22 +71,44 @@ export function createApp(context) {
 
   const router = express.Router()
   router.use(cors());
-  router.use(compression({ filter: shouldCompress }))
+  router.use(compression({
+    filter: shouldCompress
+  }))
 
-  router.use(skipIf(express.static(webappDir, {maxAge: '1h'}), isIndex))
+  router.use(skipIf(express.static(webappDir, {
+    maxAge: '1h'
+  }), isIndex))
 
   router.use(getAuthMiddleware(config))
 
-  router.use('/files', express.static(config.storage.dir, {index: false, maxAge: '2d', immutable: true}));
+  router.use('/files', express.static(config.storage.dir, {
+    index: false,
+    maxAge: '2d',
+    immutable: true
+  }));
 
   const pluginApi = browserPlugin(context, '/plugins/')
   router.use('/plugins', pluginApi.static)
 
-  router.use(bodyParser.json({limit: '1mb'}))
+  router.use(bodyParser.json({
+    limit: '1mb'
+  }))
 
-  const { read: readEvents, push: pushEvent, stream, getEvents } = eventsApi(context, config.events.file);
-  const { read: readDatabase, init: initDatabase, getFirstEntries, getDatabase } = databaseApi(context, config.database.file, getEvents);
-  const { read: readTree } = treeApi(context, getDatabase);
+  const {
+    read: readEvents,
+    push: pushEvent,
+    stream,
+    getEvents
+  } = eventsApi(context, config.events.file);
+  const {
+    read: readDatabase,
+    init: initDatabase,
+    getFirstEntries,
+    getDatabase
+  } = databaseApi(context, config.database.file, getEvents);
+  const {
+    read: readTree
+  } = treeApi(context, getDatabase);
 
   router.get('/api/events.json', readEvents);
   router.get('/api/events/stream', stream);
@@ -94,7 +118,11 @@ export function createApp(context) {
   router.use('/api/sources', getSourcesApi(config))
 
   if (config.server.remoteConsoleToken) {
-    const { console } = debugApi({remoteConsoleToken: config.server?.remoteConsoleToken})
+    const {
+      console
+    } = debugApi({
+      remoteConsoleToken: config.server?.remoteConsoleToken
+    })
     router.post('/api/debug/console', console);
   }
 
@@ -103,10 +131,12 @@ export function createApp(context) {
   router.get('/api/events', readEvents);
 
   const getWebAppState = async (req) => {
-	const HQzoom = config?.webapp?.HQzoom || false
-	const siteTitle = config?.webapp?.siteTitle || 'Home Gallery'
+    const metaTags = config?.webapp?.metaTags || false
+    const metaTagsPath = config?.webapp?.metaTagsPath || false
+    const HQzoom = config?.webapp?.HQzoom || false
+    const siteTitle = config?.webapp?.siteTitle || 'Home Gallery'
     const disabled = config?.webapp?.disabled || []
-	const removed = config?.webapp?.removed || []
+    const removed = config?.webapp?.removed || []
     const plugins = pluginApi.pluginEntries
     const entries = await getFirstEntries(50, req)
     const sources = (config.sources || []).filter(source => source.downloadable && !source.offline)
@@ -114,28 +144,37 @@ export function createApp(context) {
         const indexName = path.basename(source.index).replace(/\.[^.]+$/, '')
         return {
           indexName,
-          downloadable: true,
+          downloadable: true
         }
-    });
+      })
+    const db = await getDatabase() // <--- include full DB here
     return {
-	  HQzoom: config?.webapp?.HQzoom || false,
+      metaTags,
+      metaTagsPath,
+      HQzoom,
       disabled: !!req.username ? [...disabled, 'pwa'] : disabled,
-	  removed,
+      removed,
       pluginManager: {
         plugins
       },
       entries,
       sources,
-	  siteTitle: config?.webapp?.siteTitle || 'Home Gallery'
+      siteTitle,
+      db,
     }
   }
+
 
   const webAppOptions = {
     basePath: browserBasePath(config.server.prefix || config.server.basePath),
     injectRemoteConsole: !!config.server.remoteConsoleToken,
   }
 
-  router.use(webapp(webappDir, getWebAppState, webAppOptions))
+
+  router.get('/view/:id', webapp(webappDir, getWebAppState, webAppOptions))
+
+
+  router.get('*', webapp(webappDir, getWebAppState, webAppOptions))
 
   const prefix = routerPrefix(config.server.prefix)
   app.use(prefix, router)

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -103,6 +103,7 @@ export function createApp(context) {
   router.get('/api/events', readEvents);
 
   const getWebAppState = async (req) => {
+	const HQzoom = config?.webapp?.HQzoom || false
     const disabled = config?.webapp?.disabled || []
 	const removed = config?.webapp?.removed || []
     const plugins = pluginApi.pluginEntries
@@ -116,6 +117,7 @@ export function createApp(context) {
         }
     });
     return {
+	  HQzoom: config?.webapp?.HQzoom || false,
       disabled: !!req.username ? [...disabled, 'pwa'] : disabled,
 	  removed,
       pluginManager: {

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -104,6 +104,7 @@ export function createApp(context) {
 
   const getWebAppState = async (req) => {
 	const HQzoom = config?.webapp?.HQzoom || false
+	const siteTitle = config?.webapp?.siteTitle || 'Home Gallery'
     const disabled = config?.webapp?.disabled || []
 	const removed = config?.webapp?.removed || []
     const plugins = pluginApi.pluginEntries
@@ -125,6 +126,7 @@ export function createApp(context) {
       },
       entries,
       sources,
+	  siteTitle: config?.webapp?.siteTitle || 'Home Gallery'
     }
   }
 

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -104,6 +104,7 @@ export function createApp(context) {
 
   const getWebAppState = async (req) => {
     const disabled = config?.webapp?.disabled || []
+	const removed = config?.webapp?.removed || []
     const plugins = pluginApi.pluginEntries
     const entries = await getFirstEntries(50, req)
     const sources = (config.sources || []).filter(source => source.downloadable && !source.offline)
@@ -116,6 +117,7 @@ export function createApp(context) {
     });
     return {
       disabled: !!req.username ? [...disabled, 'pwa'] : disabled,
+	  removed,
       pluginManager: {
         plugins
       },

--- a/packages/server/src/webapp.js
+++ b/packages/server/src/webapp.js
@@ -1,5 +1,5 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'fs/promises'
+import path from 'path'
 
 import Logger from '@home-gallery/logger'
 
@@ -11,17 +11,13 @@ const readFileCached = (file, refreshMs = 10 * 1000) => {
   let lastStatTime = 0
 
   return async () => {
-    if (data && (Date.now() - lastStatTime) < refreshMs) {
-      return data
-    }
+    if (data && (Date.now() - lastStatTime) < refreshMs) return data
 
     const stat = await fs.stat(file)
     const statCache = [stat.size, stat.ctimeMs, stat.dev, stat.ino].join(':')
     lastStatTime = Date.now()
 
-    if (statCache == lastStatCache) {
-      return data
-    }
+    if (statCache == lastStatCache) return data
 
     data = await fs.readFile(file, 'utf8')
     lastStatCache = statCache
@@ -29,43 +25,128 @@ const readFileCached = (file, refreshMs = 10 * 1000) => {
   }
 }
 
-const injectStateMiddleware = (indexFile, getState, {basePath, injectRemoteConsole}) => {
+const readDbCached = (dbFile, refreshMs = 10_000) => {
+  let cache = null
+  let lastMtime = 0
+  let lastCheck = 0
 
-  const readIndex = readFileCached(indexFile)
+  return async () => {
+    const now = Date.now()
+    if (cache && (now - lastCheck) < refreshMs) return cache
+    lastCheck = now
 
-  const getIndex = async (req) => {
-    const state = await getState(req)
-    let html = await readIndex()
-
-    if (basePath && basePath != '/') {
-      html = html.replace('<base href="/">', `<base href="${basePath}">`)
+    try {
+      const stat = await fs.stat(dbFile)
+      if (stat.mtimeMs <= lastMtime && cache) return cache
+      const data = await fs.readFile(dbFile, 'utf8')
+      cache = JSON.parse(data)
+      lastMtime = stat.mtimeMs
+      return cache
+    } catch (e) {
+      log.error(e, `Could not read database file ${dbFile}`)
+      return cache || { data: [] }
     }
-    if (injectRemoteConsole) {
-      html = html.replace('</head>', '<script src="/remote-console.js"></script></head>')
-    }
-    html = html.replace('window.__homeGallery={}', `window.__homeGallery=${JSON.stringify(state)}`)
-
-    return html
-  }
-
-  return (req, res) => {
-    getIndex(req)
-      .then(html => {
-        res.set({
-          'Content-Type': 'text/html; charset=utf-8',
-          'Cache-Control': 'no-store, no-cache',
-          'Content-Length': html.length,
-        })
-        res.send(html);
-      })
-      .catch(err => {
-        log.error(err, `Could not read index file ${indexFile}: ${err}`)
-        return res.status(404).json({error: `${err}`, message: `Failed to read index.html. Please see server logs for details`});
-      })
   }
 }
 
-export const webapp = (webappDir, getState, options) => {
+const injectStateMiddleware = (indexFile, getState, {
+  basePath = '/',
+  injectRemoteConsole = false,
+}) => {
+  const readIndex = readFileCached(indexFile)
+
+  return async (req, res) => {
+    console.log('[DEBUG] injectStateMiddleware called for', req.path)
+
+    let html = await readIndex()
+    const state = await getState(req) || {}
+
+    if (basePath && basePath !== '/') {
+      html = html.replace('<base href="/">', `<base href="${basePath}">`)
+    }
+
+    if (injectRemoteConsole) {
+      html = html.replace('</head>', '<script src="/remote-console.js"></script></head>')
+    }
+
+    html = html.replace('window.__homeGallery={}', `window.__homeGallery=${JSON.stringify(state)}`)
+    if (state.metaTags) {
+      const match = req.path.match(/^\/view\/([a-f0-9]+)/)
+      if (match) {
+        const shortId = match[1]
+        console.log('[DEBUG] Matched /view/:id route, shortId=', shortId)
+
+        const db = state.db || { data: [] }
+        const media = db.data?.find(m => m.id.startsWith(shortId))
+
+        if (!media) {
+          console.log('[DEBUG] No media found for shortId=', shortId)
+        } else {
+          console.log('[DEBUG] Found media:', media)
+
+          const fullHash = media.filenameHash || media.id
+
+          const availableSizes = media.previews
+            .map(p => {
+              const m = p.match(/-image-preview-(\d+)\.jpg$/)
+              return m ? parseInt(m[1], 10) : null
+            })
+            .filter(Boolean)
+
+          const largestSize = Math.max(...availableSizes)
+          const imageUrl = `${req.protocol}://${req.get('host')}${basePath.replace(/\/$/, '')}/files/${fullHash.slice(0,2)}/${fullHash.slice(2,4)}/${fullHash.slice(4)}-image-preview-${largestSize}.jpg`
+
+          const rawFilename = media.files?.[0]?.filename || media.originalFilename || 'Photo'
+          const title = !state.metaTagsPath
+            ? rawFilename.replace(/^.*\//, '') // last dir / filename
+            : rawFilename.replace(/^.*\/([^\/]+\/[^\/]+)$/, '$1') // second-to-last dir / filename
+          
+          const themeColor = (media.vibrantColors?.[0]) || "#7289DA"
+          const descriptionParts = [
+            media.model,
+            media.iso ? `ISO/${media.iso}` : '',
+            media.shutterSpeed ? `${media.shutterSpeed}s` : '',
+            media.aperture ? `f/${media.aperture}` : '',
+            media.focalLength ? `${media.focalLength}mm` : ''
+          ]
+          const description = descriptionParts.filter(Boolean).join(' | ')
+
+          const meta = `
+<meta name="twitter:card" content="summary_large_image">
+<meta name="theme-color" content="${themeColor}">
+<meta property="og:title" content="${title}" />
+<meta property="og:description" content="${description}" />
+<meta property="og:image" content="${imageUrl}" />
+<meta property="og:type" content="article" />
+<meta property="og:image:height" content="1920" />
+`
+          const headIndex = html.indexOf('<head>')
+          if (headIndex !== -1) {
+            html = html.slice(0, headIndex + '<head>'.length) + meta + '\n' + html.slice(headIndex + '<head>'.length)
+            console.log('[DEBUG] Injected meta tags for shortId=', shortId)
+          } else {
+            console.log('[DEBUG] No <head> tag found, cannot inject meta tags')
+          }
+        }
+      }
+    }
+
+    res.set({
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store, no-cache',
+      'Content-Length': Buffer.byteLength(html, 'utf8'),
+    })
+    res.send(html)
+  }
+}
+
+export const webapp = (webappDir, getState, options = {}) => {
   const indexFile = path.resolve(webappDir, 'index.html')
-  return injectStateMiddleware(indexFile, getState, options)
+  const dbFile = path.resolve(webappDir, '..', 'gallery.db')
+  const appConfig = options.appConfig || {}
+  return injectStateMiddleware(indexFile, getState, {
+    ...options,
+    dbFile,
+    appConfig
+  })
 }

--- a/packages/webapp/src/init/AppLoading.tsx
+++ b/packages/webapp/src/init/AppLoading.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react"
-
+import { useAppConfig } from "../utils/useAppConfig";
 type TAppLoadingProps = {
   isLoading: boolean
   hasError: boolean
@@ -47,6 +47,14 @@ const AppIcon : React.FC<{state: TAppLoadingProps}> = ({state}) => {
 }
 
 export const AppLoading : React.FC<{state: TAppLoadingProps}> = ({state}) => {
+  const appConfig = useAppConfig();
+
+  useEffect(() => {
+    if (appConfig.siteTitle) {
+      document.title = appConfig.siteTitle;
+    }
+  }, [appConfig.siteTitle]);
+
   return (
     <div id="app-loader">
       <div className="container">
@@ -61,5 +69,6 @@ export const AppLoading : React.FC<{state: TAppLoadingProps}> = ({state}) => {
     </div>
   )
 }
+
 
 export default AppLoading

--- a/packages/webapp/src/navbar/ViewNavBar.tsx
+++ b/packages/webapp/src/navbar/ViewNavBar.tsx
@@ -18,7 +18,14 @@ export const ViewNavBar = ({disableEdit}) => {
   const navigate = useNavigate();
   const listLocation = useListLocation()
   const appConfig = useAppConfig()
-
+  const itemKeys = {
+    'Show All': 'globe',
+    'Years': 'years',
+    'Videos': 'videos',
+    'Edit': 'edit',
+    'Tags': 'tags',
+    'Map': 'map'
+  }
   const items = [
     {
       icon: icons.faGlobe,
@@ -65,10 +72,16 @@ export const ViewNavBar = ({disableEdit}) => {
       disabled: false,
     },
   ]
-
+  const finalItems = items.map(item => {
+    const key = itemKeys[item.text]
+    const isRemoved = appConfig.removed?.includes(key)
+    const isDisabled = (key === 'edit' && (disableEdit || appConfig.disabledEdit))
+    return isRemoved ? null : {...item, disabled: !!isDisabled}
+  }).filter(Boolean)
+  
   return (
     <>
-      {items.map((item, key) => (
+      {finalItems.map((item, key) => (
         <NavItem key={key} onClick={item.action} icon={item.icon} text={item.text} disabled={item.disabled} />
       ))}
     </>

--- a/packages/webapp/src/single/MediaNav.tsx
+++ b/packages/webapp/src/single/MediaNav.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import * as icons from '@fortawesome/free-solid-svg-icons'
 
 import { useSearchStore } from "../store/search-store";
+import { useAppConfig } from "../utils/useAppConfig"; // <-- added
 
 import { getHigherPreviewUrl, getLowerPreviewUrl } from '../utils/preview'
 import { usePreviewSize } from "./usePreviewSize";
@@ -12,6 +13,7 @@ import { classNames } from '../utils/class-names'
 export const MediaNav = ({current, prev, next, listLocation, showNavigation, dispatch}) => {
   const query = useSearchStore(state => state.query);
   const previewSize = usePreviewSize()
+  const appConfig = useAppConfig() // <-- added
 
   const loadImage = async (url: string | false) => {
     return new Promise((resolve) => {
@@ -55,18 +57,20 @@ export const MediaNav = ({current, prev, next, listLocation, showNavigation, dis
   return (
     <>
       <div className={classNames('absolute z-10 top-4 right-4 flex gap-2')}>
-        <a onClick={() => dispatch({type: 'list'})} className={classNames(buttonClass, itemClass, 'bg-transparent hover:bg-gray-400/40')} title="Show media stream (ESC)">
-          <FontAwesomeIcon icon={icons.faXmark} className={iconClass}/>
-        </a>
+        {!appConfig.removedViewerStream &&
+          <a onClick={() => dispatch({type: 'list'})} className={classNames(buttonClass, itemClass, 'bg-transparent hover:bg-gray-400/40')} title="Show media stream (ESC)">
+            <FontAwesomeIcon icon={icons.faXmark} className={iconClass}/>
+          </a>
+        }
       </div>
-      { prev &&
+      {!appConfig.removedViewerNav && prev &&
         <div className={classNames('absolute z-10 left-4 top-1/2 -translate-y-1/2', itemClass)}>
           <a onClick={() => dispatch({type: 'prev'})} className={classNames(buttonClass, buttonBgClass)} title="Show previous media (left arrow)">
             <FontAwesomeIcon icon={icons.faChevronLeft} className={iconClass}/>
           </a>
         </div>
       }
-      { next &&
+      {!appConfig.removedViewerNav && next &&
         <div className={classNames('absolute z-10 right-4 top-1/2 -translate-y-1/2', itemClass)}>
           <a onClick={() => dispatch({type: 'next'})} className={classNames(buttonClass, buttonBgClass)} title="Show next media (right arrow)">
             <FontAwesomeIcon icon={icons.faChevronRight} className={iconClass}/>
@@ -74,32 +78,32 @@ export const MediaNav = ({current, prev, next, listLocation, showNavigation, dis
         </div>
       }
       <div className={classNames('absolute z-10 bottom-4 left-1/2 -translate-x-1/2 flex gap-2')}>
-        { listLocation &&
+        {!appConfig.removedViewerStream && listLocation &&
           <a onClick={() => dispatch({type: 'list'})} className={classNames(buttonClass, buttonBgClass, itemClass)} title="Show media stream (ESC)">
             <FontAwesomeIcon icon={icons.faTh} className={iconClass}/>
           </a>
         }
-        { hasGeo &&
+        {!appConfig.removedViewerMap && hasGeo &&
           <a onClick={() => dispatch({type: 'map'})} className={classNames(buttonClass, buttonBgClass, itemClass)} title="Show map of entry (m)">
             <FontAwesomeIcon icon={icons.faMap} className={iconClass}/>
           </a>
         }
-        { current?.similarityHash &&
+        {!appConfig.removedViewerLeaf && current?.similarityHash &&
           <a onClick={() => dispatch({type: 'similar'})} className={classNames(buttonClass, buttonBgClass, itemClass)} title="Show similar images (s)">
             <FontAwesomeIcon icon={icons.faSeedling} className={iconClass}/>
           </a>
         }
-        { query.type != 'none' &&
+        {!appConfig.removedViewerYears && query.type != 'none' &&
           <a onClick={() => dispatch({type: 'chronology'})} className={classNames(buttonClass, buttonBgClass, itemClass)} title="Show chronology (c)">
             <FontAwesomeIcon icon={icons.faClock} className={iconClass}/>
           </a>
         }
-        { current && (current.faces?.length > 0 || current.objects?.length > 0) &&
+        {!appConfig.removedViewerAI && current && (current.faces?.length > 0 || current.objects?.length > 0) &&
           <a onClick={() => dispatch({type: 'toggleAnnotations'})} className={classNames(buttonClass, buttonBgClass, itemClass)} title="Show object and face annotations (a)">
             <FontAwesomeIcon icon={icons.faUsersViewfinder} className={iconClass}/>
           </a>
         }
-        { current &&
+        {!appConfig.removedViewerInfo && current &&
           <a onClick={() => dispatch({type: 'toggleDetails'})} className={classNames(buttonClass, buttonBgClass, itemClass)} title="Show detail info (i)">
             <FontAwesomeIcon icon={icons.faInfo} className={iconClass}/>
           </a>
@@ -108,4 +112,3 @@ export const MediaNav = ({current, prev, next, listLocation, showNavigation, dis
     </>
   )
 }
-

--- a/packages/webapp/src/single/MediaNav.tsx
+++ b/packages/webapp/src/single/MediaNav.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import * as icons from '@fortawesome/free-solid-svg-icons'
 
 import { useSearchStore } from "../store/search-store";
-import { useAppConfig } from "../utils/useAppConfig"; // <-- added
+import { useAppConfig } from "../utils/useAppConfig";
 
 import { getHigherPreviewUrl, getLowerPreviewUrl } from '../utils/preview'
 import { usePreviewSize } from "./usePreviewSize";
@@ -13,7 +13,7 @@ import { classNames } from '../utils/class-names'
 export const MediaNav = ({current, prev, next, listLocation, showNavigation, dispatch}) => {
   const query = useSearchStore(state => state.query);
   const previewSize = usePreviewSize()
-  const appConfig = useAppConfig() // <-- added
+  const appConfig = useAppConfig()
 
   const loadImage = async (url: string | false) => {
     return new Promise((resolve) => {

--- a/packages/webapp/src/single/MediaView.tsx
+++ b/packages/webapp/src/single/MediaView.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-router-dom";
 import Hammer from 'hammerjs';
 import { useHotkeys } from 'react-hotkeys-hook';
-
+import { useAppConfig } from "../utils/useAppConfig";
 import { useEntryStore } from "../store/entry-store";
 import { useSearchStore } from "../store/search-store";
 import { useSingleViewStore } from "../store/single-view-store";
@@ -77,6 +77,7 @@ const hotkeyToAction = Object.entries(hotkeysToAction).reduce((result, [hotkeys,
 }, {})
 
 export const MediaView = () => {
+  const appConfig = useAppConfig();
   let { id } = useParams();
   let location = useLocation();
   const navigate = useNavigate();
@@ -170,7 +171,13 @@ export const MediaView = () => {
     const handlerKey = (handler.ctrl ? 'ctrl+' : '') + (handler.shift ? 'shift+' : '') + (handler.alt ? 'alt+' : '') + (handler.keys || []).join('+')
     const action = hotkeyToAction[handlerKey]
     if (action) {
-      console.log(`Catch hotkey ${handlerKey} for action ${action}`)
+      if ((action === 'prev' || action === 'next' || action.startsWith('prev-') || action.startsWith('next-')) && appConfig.removedViewerNav) return;
+      if (action === 'list' && appConfig.removedViewerStream) return;
+      if (action === 'map' && appConfig.removedViewerMap) return;
+      if (action === 'chronology' && appConfig.removedViewerLeaf) return;
+      if (action === 'similar' && appConfig.removedViewerAI) return;
+      if (action === 'toggleDetails' && appConfig.removedViewerInfo) return;
+      if (action === 'toggleAnnotations' && appConfig.removedViewerAI) return;
       dispatch({type: action})
       ev.preventDefault()
     }

--- a/packages/webapp/src/single/MediaView.tsx
+++ b/packages/webapp/src/single/MediaView.tsx
@@ -97,6 +97,8 @@ export const MediaView = () => {
   const setShowNavigation = useSingleViewStore(actions => actions.setShowNavigation);
 
   const [hideNavigation, setHideNavigation] = useState(false)
+  
+  const [zoomFactor, setZoomFactor] = useState(1);
 
   let index = findEntryIndex(location, entries, id);
 
@@ -110,7 +112,7 @@ export const MediaView = () => {
 
   const key = current ? current.id : (Math.random() * 100000).toFixed(0);
   const scaleSize = scaleDimensions(current, dimensions);
-  console.log(scaleSize, dimensions, current);
+  //console.log(scaleSize, dimensions, current);
 
   useEffect(() => { id && setLastId(id) }, [id])
   useEffect(() => { index >= 0 && setLastIndex(index) }, [index])
@@ -192,8 +194,8 @@ export const MediaView = () => {
     dispatch({type: 'list'})
   }
 
-  console.log('Media object', current, showDetails);
-
+  //console.log('Media object', current, showDetails);
+  //console.log(appConfig)
   return (
     <>
       <SingleTagDialogProvider>
@@ -204,8 +206,8 @@ export const MediaView = () => {
                 <MediaNav index={index} current={current} prev={prev} next={next} listLocation={listLocation} showNavigation={showNavigation} dispatch={dispatch} />
               }
               {isImage &&
-                <Zoomable key={key} childWidth={current.width} childHeight={current.height} onSwipe={onSwipe}>
-                  <MediaViewImage key={key} media={current} next={next} prev={prev} showAnnotations={showAnnotations}/>
+                <Zoomable key={key} childWidth={current.width} childHeight={current.height} onSwipe={onSwipe} onZoom={(scale) => setZoomFactor(scale)}>
+                  <MediaViewImage key={key} media={current} next={next} prev={prev} showAnnotations={showAnnotations} hqZoom={appConfig.HQzoom} zoomFactor={zoomFactor}/>
                 </Zoomable>
               }
               {isVideo &&

--- a/packages/webapp/src/single/MediaViewImage.tsx
+++ b/packages/webapp/src/single/MediaViewImage.tsx
@@ -11,25 +11,26 @@ export const MediaViewImage = (props) => {
   const imgRect = useClientRect(imgRef);
   const [faceRects, setFaceRects] = useState([]);
   const [objectRects, setObjectRects] = useState([]);
-  const { showAnnotations } = props;
-  const { id, shortId, previews, faces, objects } = props.media;
+  const { showAnnotations, hqZoom = false, zoomFactor = 1 } = props;
+  const { id, shortId, previews, faces, objects, fullSize } = props.media;
   const navigate = useNavigate();
   const previewSize = usePreviewSize()
-
   const smallUrl = getLowerPreviewUrl(previews, previewSize / 4)
-  const largeUrl = getHigherPreviewUrl(previews, previewSize)
-  const [src, setSrc] = useState('');
+  const highPreviewUrl = getHigherPreviewUrl(previews, previewSize)
+  const maxPreviewUrl = getHigherPreviewUrl(previews, Number.MAX_SAFE_INTEGER)
+  const [src, setSrc] = useState(smallUrl)
 
   useEffect(() => {
-    if (!largeUrl) {
-      return
+    let selectedUrl = highPreviewUrl;
+    if (hqZoom && zoomFactor > 1) {
+      selectedUrl = fullSize || maxPreviewUrl;
     }
+    if (!selectedUrl || selectedUrl === src) return;
+    //console.log("HQzoom:", hqZoom, "zoomFactor:", zoomFactor, "fullSize:", fullSize, "selected:", selectedUrl)
     const img = new Image();
-    img.addEventListener('load', () => {
-      setSrc(largeUrl);
-    });
-    img.src = largeUrl;
-  }, []);
+    img.onload = () => setSrc(selectedUrl);
+    img.src = selectedUrl;
+  }, [hqZoom, zoomFactor, fullSize, highPreviewUrl, maxPreviewUrl, src]);
 
   const selectFace = (shortId, faceNo) => {
     console.log(`Search for face ${faceNo} of ${shortId}`);

--- a/packages/webapp/src/single/Zoomable.tsx
+++ b/packages/webapp/src/single/Zoomable.tsx
@@ -21,10 +21,11 @@ const containsSize = (containerWidth, containerHeight, childWidth, childHeight) 
 type ZoomableProps = {
   childWidth: number;
   childHeight: number;
-  onSwipe?: (ev: HammerInput) => void
+  onSwipe?: (ev: HammerInput) => void;
+  onZoom?: (scale: number) => void;
 }
 
-export const Zoomable: FunctionComponent<ZoomableProps> = ({childWidth, childHeight, onSwipe, children}) => {
+export const Zoomable: FunctionComponent<ZoomableProps> = ({childWidth, childHeight, onSwipe, onZoom, children}) => {
   const ref = useRef<HTMLDivElement>();
   const [style, setStyle] = useState({});
   const clientRect = useClientRect(ref);
@@ -91,6 +92,7 @@ export const Zoomable: FunctionComponent<ZoomableProps> = ({childWidth, childHei
 
       logEvent(ev);
       requestElementUpdate();
+	  if (onZoom) onZoom(transform.scale); 
     }
 
     let onPinchHandler = (ev) => {
@@ -102,6 +104,7 @@ export const Zoomable: FunctionComponent<ZoomableProps> = ({childWidth, childHei
 
       logEvent(ev);
       requestElementUpdate();
+	  if (onZoom) onZoom(transform.scale); 
     }
 
     const onSwipeHandler = (ev) => {
@@ -133,6 +136,7 @@ export const Zoomable: FunctionComponent<ZoomableProps> = ({childWidth, childHei
       }
       logEvent(ev);
       requestElementUpdate();
+	  if (onZoom) onZoom(transform.scale); 
     }
 
     resetElement();
@@ -172,6 +176,7 @@ export const Zoomable: FunctionComponent<ZoomableProps> = ({childWidth, childHei
 
       logEvent(ev);
       requestElementUpdate();
+	  if (onZoom) onZoom(transform.scale); 
     }
 
     el.addEventListener('wheel', onWheel)

--- a/packages/webapp/src/utils/useAppConfig.ts
+++ b/packages/webapp/src/utils/useAppConfig.ts
@@ -8,6 +8,7 @@ const defaultConfig = {
    *
    * A feature will be expanded to `disabledEdit: true`
    */
+  siteTitle: "Home Gallery",
   HQzoom: false,
   disabled: [],
   removed: [],

--- a/packages/webapp/src/utils/useAppConfig.ts
+++ b/packages/webapp/src/utils/useAppConfig.ts
@@ -1,5 +1,5 @@
 const defaultConfig = {
-  /**
+   /**
    * List of disabled features
    *
    * - edit: No edit menu button
@@ -9,6 +9,7 @@ const defaultConfig = {
    * A feature will be expanded to `disabledEdit: true`
    */
   disabled: [],
+  removed: [],
   pluginManager: {
     plugins: []
   },
@@ -17,6 +18,7 @@ const defaultConfig = {
 
 export const useAppConfig = () => {
   const injectedConfig = window['__homeGallery'] || {};
+  const webappConfig = injectedConfig.webapp || {};
 
   const pluginManager = {
     ...defaultConfig.pluginManager,
@@ -26,17 +28,33 @@ export const useAppConfig = () => {
   const result = {
     ...defaultConfig,
     ...injectedConfig,
+    ...webappConfig,
     pluginManager
   }
 
   const searchParams = new URLSearchParams(location.search?.substring(1) || '')
-  result.disabled.push(...searchParams.getAll('disabled').filter(v => !!v))
+
+  result.disabled = [
+    ...(defaultConfig.disabled || []),
+    ...(injectedConfig.disabled || []),
+    ...(webappConfig.disabled || []),
+    ...searchParams.getAll('disabled').filter(v => !!v)
+  ]
+
+  result.removed = [
+    ...(defaultConfig.removed || []),
+    ...(injectedConfig.removed || []),
+    ...(webappConfig.removed || []),
+    ...searchParams.getAll('removed').filter(v => !!v)
+  ]
 
   result.disabled.forEach((feature: string) => {
-    const name = `disabled${feature[0].toUpperCase()}${feature.slice(1)}`
-    result[name] = true
+    result[`disabled${feature[0].toUpperCase()}${feature.slice(1)}`] = true
   })
 
+	result.removed.forEach((feature: string) => {
+	  const name = `removed${feature[0].toUpperCase()}${feature.slice(1)}`
+	  result[name] = true
+	})
   return result
 }
-

--- a/packages/webapp/src/utils/useAppConfig.ts
+++ b/packages/webapp/src/utils/useAppConfig.ts
@@ -8,7 +8,9 @@ const defaultConfig = {
    *
    * A feature will be expanded to `disabledEdit: true`
    */
-  siteTitle: "Home Gallery",
+  metaTags: false,
+  metaTagsPath: false,
+  siteTitle: "My Gallery",
   HQzoom: false,
   disabled: [],
   removed: [],

--- a/packages/webapp/src/utils/useAppConfig.ts
+++ b/packages/webapp/src/utils/useAppConfig.ts
@@ -8,6 +8,7 @@ const defaultConfig = {
    *
    * A feature will be expanded to `disabledEdit: true`
    */
+  HQzoom: false,
   disabled: [],
   removed: [],
   pluginManager: {


### PR DESCRIPTION
Fixes https://github.com/xemle/home-gallery/issues/188
Fixes https://github.com/xemle/home-gallery/issues/189
Fixes https://github.com/xemle/home-gallery/issues/159
Fixes https://github.com/xemle/home-gallery/issues/191

```
webapp:
  metaTags: true          # enable meta tags for discord/other
  metaTagsPath: true      # include the last dir of path Foldername/DSC1337.JPG or false for just DSC1337.JPG

  HQzoom: true            # enables HQ zooming*
  
  removed:
    #- globe               # Show All (mainpage)
    #- folders             # Folders (mainpage)
    #- years               # Years (mainpage)
    - videos              # Videos (mainpage)
    - edit                # Edit (mainpage)
    - tags                # Tags (mainpage)
    - map                 # Map (mainpage)
    # Viewer-specific buttons
    #- viewerNav           # left/right arrows + bindings
    #- viewerStream        # stream/grid view + bindings
    - viewerMap           # map button in viewer + bindings
    #- viewerLeaf          # leaf/similar images button + bindings
    #- viewerYears         # chronology button + bindings
    #- viewerAI            # object/face annotations + bindings
    #- viewerInfo          # info/details + bindings
	
	
# * caveat; HQzoom still relies on extractor -> image ->previewSizes
# with HQzoom, on zooming it will lock to the maximum previewsize stated that is EQUAL OR SMALLER than the image
# extractor cannot upscale, so just add the common width + height of your camera/other
# set this flag, and it will automatically jump to raw res or the biggest it can find that will fit the moment you zoom
# normal browsing behaviour is totally untouched
```