### PR TITLE
Add Dockerfile and docker compose files specifically for a development

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -1,0 +1,23 @@
+FROM node:22-alpine
+
+RUN apk add --no-cache \
+  ffmpeg \
+  vips-tools \
+  perl
+
+WORKDIR /app
+
+ENV HOME=/data
+ENV GALLERY_BASE_DIR=/data
+ENV GALLERY_CONFIG_DIR=/data/config
+ENV GALLERY_CACHE_DIR=/data
+ENV GALLERY_CONFIG=/data/config/gallery.config.yml
+ENV GALLERY_OPEN_BROWSER=false
+ENV GALLERY_USE_NATIVE=ffprobe,ffmpeg
+# Use polling for safety of possible network mounts. Try 0 to use inotify via fs.watch
+ENV GALLERY_WATCH_POLL_INTERVAL=300
+ENV NODE_ENV=development
+
+EXPOSE 3000 5173
+
+CMD npm install --verbose && npm run build && node gallery.js run server

--- a/docker-compose-development.nginx-proxy.yml
+++ b/docker-compose-development.nginx-proxy.yml
@@ -1,0 +1,24 @@
+# This is for using with nginx-proxy
+# https://github.com/nginx-proxy/nginx-proxy
+#
+# Usage:
+#   export COMPOSE_FILE="docker-compose-development.yml:docker-compose-development.nginx-proxy.yml"
+#   export HOME_GALLERY_HOST=dev.home-gallery.example.com
+#   docker compose build && docker compose up
+services:
+  gallery:
+    environment:
+      VIRTUAL_PORT: 3000
+      VIRTUAL_HOST_MULTIPORTS: |-
+        "${HOME_GALLERY_HOST:-home-gallery.localhost}":
+          "/api":
+            port: 3000
+          "/files":
+            port: 3000
+    #volumes:
+      #- /home/Pictures:/data/Pictures
+  webapp:
+    environment:
+      VIRTUAL_HOST: '${HOME_GALLERY_HOST:-home-gallery.localhost}'
+      VIRTUAL_PORT: 5173
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: '${HOME_GALLERY_HOST:-home-gallery.localhost}'

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,0 +1,50 @@
+# This docker-compose file is meant to make development easier as no part of the app will run on the host system
+# For even easier use it's recommended to use the docker-compose-development.nginx-proxy.yml file as well.
+name: home-gallery-development
+services:
+  api:
+    build:
+      context: packages/api-server
+      dockerfile: Dockerfile-development
+    volumes:
+      - ./packages/api-server:/app
+    user: "${USER_ID:-1000}:${GROUP_ID:-1000}"
+    environment:
+      # TensorflowJS backends
+      # - cpu: slowest and best support
+      # - wasm: good perfromance for arm64 and amd64 platforms
+      # - node: best performance on amd64 platform
+      #- BACKEND=cpu
+      - BACKEND=wasm
+      #- BACKEND=node
+  gallery:
+    build:
+      context: .
+      dockerfile: Dockerfile-development
+    environment:
+      #- NODE_OPTIONS=--max-old-space-size=4096 # On larger galleries increase memory limit
+      - GALLERY_API_SERVER=http://api:3000
+      - GALLERY_API_SERVER_CONCURRENT=5 # for SoC devices like Rasperry Pi. Use 5 otherwise
+      - GALLERY_API_SERVER_TIMEOUT=30 # for SoC devices like Rasperry Pi. Use 30 otherwise
+      #- GALLERY_USE_NATIVE=ffprobe,ffmpeg,vipsthumbnail # On issues with sharp resizer
+      # Use polling for safety of possible network mounts. Try 0 to use inotify via fs.watch
+      - GALLERY_WATCH_POLL_INTERVAL=0
+    user: "${USER_ID:-1000}:${GROUP_ID:-1000}"
+    volumes:
+      - .:/app
+      - ./data:/data
+      - ${GALLERY_CONFIG_FILE:-./gallery.config-development.yml}:/data/config/gallery.config.yml
+    ports: ["3000"]
+  webapp:
+    depends_on:
+      - gallery
+      - api
+    build:
+      context: .
+      dockerfile: Dockerfile-development
+    ports: ["5173"]
+    volumes:
+      - .:/app
+    working_dir: "/app/packages/webapp"
+    command: "npm run dev -- --host"
+    user: "${USER_ID:-1000}:${GROUP_ID:-1000}"

--- a/gallery.config-development.yml
+++ b/gallery.config-development.yml
@@ -1,0 +1,4 @@
+# Only used for development to have that one sensible default setting
+sources:
+  - /data/Pictures
+

--- a/packages/api-server/Dockerfile-development
+++ b/packages/api-server/Dockerfile-development
@@ -1,0 +1,7 @@
+FROM node:20
+
+WORKDIR /app
+
+EXPOSE 3000
+
+CMD sh -c 'npm install && node download-models.js && node index.js'


### PR DESCRIPTION
Give it a try and I'll update the [docs](https://github.com/xemle/home-gallery-doc/blob/master/source/development/index.rst) once this is merged.

I'd recommend that you first get nginx-proxy working, I use it both on my dev machine, homelab and staging servers.

```
export COMPOSE_FILE="docker-compose-development.yml:docker-compose-development.nginx-proxy.yml"                                                                                                               
export HOME_GALLERY_HOST=dev.home-gallery.example.com                                                                                                                                                         
docker compose build && docker compose up                                                                                                                                                                     
```

(obviously change the HOST)