### PR TITLE
Add webapp.title to config schema

### DIFF
--- a/gallery.config-example.yml
+++ b/gallery.config-example.yml
@@ -305,6 +305,8 @@
 
 # Configuration for webapp module
 #webapp:
+  # default: 'Home Gallery'
+  #title: 'Home Gallery'
   #pluginManager:
     #
     # List of plugin urls to load

--- a/gallery.config.schema.json
+++ b/gallery.config.schema.json
@@ -561,6 +561,13 @@
       "description": "Configuration for webapp module",
       "type": "object",
       "properties": {
+	"title": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://raw.githubusercontent.com/xemle/home-gallery/master/gallery.config.schema.json#webapp.pluginManager",
+          "title": "Title",
+	  "type": "string",
+	  "default": "Home Gallery"
+	},
         "pluginManager": {
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://raw.githubusercontent.com/xemle/home-gallery/master/gallery.config.schema.json#webapp.pluginManager",


### PR DESCRIPTION
Besides the missing title, a few defaults have changed. E.g. `sources.offline` defaults to true now.

Best way to see the difference:
`git diff -uw a387f80^ gallery.config-example.yml`